### PR TITLE
Add pytest tests for soil_agent

### DIFF
--- a/tests/test_soil_agent.py
+++ b/tests/test_soil_agent.py
@@ -1,0 +1,58 @@
+import os
+import pytest
+from pathlib import Path
+
+from agent_test.soil_agent import soil_agent, get_soil_ph_image
+
+@pytest.fixture(scope="module")
+def setup_test_bounds():
+    # Define a small test region bounds
+    return {
+        "west": -1784000,
+        "south": 1356000,
+        "east": -1783000,
+        "north": 1357000,
+    }
+
+@pytest.fixture(scope="function")
+def cleanup_soil_ph_map_file():
+    # Ensure the soil_ph_map.tif file is deleted before and after the test
+    yield
+    if Path("soil_ph_map.tif").exists():
+        Path("soil_ph_map.tif").unlink()
+
+def test_get_soil_ph_image(setup_test_bounds, cleanup_soil_ph_map_file):
+    bounds = setup_test_bounds
+    try:
+        result = get_soil_ph_image(
+            west=bounds["west"],
+            south=bounds["south"],
+            east=bounds["east"],
+            north=bounds["north"],
+        )
+
+        # Check that metadata is returned
+        assert isinstance(result, str)
+        assert "phh2o" in result.lower()
+        assert "soil_ph_map.tif" in Path("soil_ph_map.tif").name
+
+        # Check that the file exists
+        assert Path("soil_ph_map.tif").exists()
+    except Exception as e:
+        pytest.fail(f"test_get_soil_ph_image failed: {e}")
+
+def test_agent_tool_integration(setup_test_bounds, cleanup_soil_ph_map_file):
+    query = (
+        "Show me a soil pH map for the region west=-1784000, "
+        "south=1356000, east=-1783000, north=1357000"
+    )
+    try:
+        result = soil_agent.run_sync(query)
+        data = result.data
+
+        # Check that agent returns meaningful data
+        assert data is not None
+        assert "phh2o" in data.lower()
+        assert "soil_ph_map.tif" in data
+    except Exception as e:
+        pytest.fail(f"test_agent_tool_integration failed: {e}")


### PR DESCRIPTION
- Introduce a pytest fixture to set up test bounds for a small region.
- Add test_get_soil_ph_image function to verify the output of get_soil_ph_image, ensuring the correct metadata is returned and the file exists.
- Add test_agent_tool_integration function to verify the soil_agent's response to a specific query.
- Ensure file cleanup after tests to avoid interference with other tests.
- Add error handling to provide informative error messages if the functions fail.